### PR TITLE
Update import logic

### DIFF
--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -1,11 +1,4 @@
-import { store } from '../store/reducer';
-import actions from '../store/actions';
-import { initialState as boardInitialState } from '../store/board';
-import { initialState as columnsInitialState } from '../store/columns';
-import { initialState as cardsInitialState } from '../store/cards';
-import { initialState as tagsInitialState } from '../store/tags';
-
-const { importCards, importColumns, importBoard, importTags } = actions;
+import rootReducer, { store } from '../store/reducer';
 
 export const exportToJSON = () => {
   const { board, cards, columns, tags } = store.getState();
@@ -22,14 +15,18 @@ export const importFromJSON = fileList => {
   const reader = new FileReader();
   reader.addEventListener('load', event => {
     const { board, cards, columns, tags } = JSON.parse(event.target.result);
-    store.dispatch(importBoard(boardInitialState));
-    store.dispatch(importColumns(columnsInitialState));
-    store.dispatch(importCards(cardsInitialState));
-    store.dispatch(importTags(tagsInitialState));
-    store.dispatch(importTags(tags));
-    store.dispatch(importCards(cards));
-    store.dispatch(importColumns(columns));
-    store.dispatch(importBoard(board));
-  });
+    store.replaceReducer(state => {
+      return {
+        interface: state.interface,
+        board,
+        cards,
+        columns,
+        tags
+      };
+    });
+    store.dispatch({ type: 'IMPORT_FROM_JSON' });
+    store.replaceReducer(rootReducer);
+    document.getElementById('main-menu-load-json').value = '';
+  }, { once: true });
   reader.readAsText(file);
 };

--- a/src/store/board.js
+++ b/src/store/board.js
@@ -5,8 +5,7 @@ export const initialState = {
 };
 
 export const actionTypes = {
-  SET_BOARD_TITLE: 'SET_BOARD_TITLE',
-  IMPORT_BOARD: 'IMPORT_BOARD'
+  SET_BOARD_TITLE: 'SET_BOARD_TITLE'
 };
 
 const reducer = (state = initialState, action) => {
@@ -16,8 +15,6 @@ const reducer = (state = initialState, action) => {
       ...state,
       title: action.title
     };
-  case actionTypes.IMPORT_BOARD:
-    return action.data;
   default:
     return state;
   }
@@ -28,12 +25,6 @@ export const actions = {
     return {
       type: actionTypes.SET_BOARD_TITLE,
       title
-    };
-  },
-  importBoard: data => {
-    return {
-      type: actionTypes.IMPORT_BOARD,
-      data
     };
   }
 };

--- a/src/store/cards.js
+++ b/src/store/cards.js
@@ -9,7 +9,6 @@ export const actionTypes = {
   CREATE_CARD: 'CREATE_CARD',
   SET_CARD_TITLE: 'SET_CARD_TITLE',
   SET_CARD_DESCRIPTION: 'SET_CARD_DESCRIPTION',
-  IMPORT_CARDS: 'IMPORT_CARDS',
   SET_PRIORITY: 'SET_PRIORITY',
   ADD_TAG: 'ADD_TAG',
   REMOVE_TAG: 'REMOVE_TAG'
@@ -38,8 +37,6 @@ const reducer = (state = initialState, action) => {
         description: action.description
       }
     };
-  case actionTypes.IMPORT_CARDS:
-    return action.data;
   case actionTypes.SET_PRIORITY:
     return {
       ...state,
@@ -102,12 +99,6 @@ export const actions = {
       type: actionTypes.SET_CARD_DESCRIPTION,
       description,
       id
-    };
-  },
-  importCards: data => {
-    return {
-      type: actionTypes.IMPORT_CARDS,
-      data
     };
   },
   setCardPriority: (id, priority) => {

--- a/src/store/columns.js
+++ b/src/store/columns.js
@@ -6,7 +6,6 @@ export const initialState = {};
 export const actionTypes = {
   CREATE_COLUMN: 'CREATE_COLUMN',
   ADD_CARD_TO_COLUMN: 'ADD_CARD_TO_COLUMN',
-  IMPORT_COLUMNS: 'IMPORT_COLUMNS',
   REMOVE_CARD_FROM_COLUMN: 'REMOVE_CARD_FROM_COLUMN',
   MOVE_CARD_INSIDE_COLUMN: 'MOVE_CARD_INSIDE_COLUMN'
 };
@@ -45,8 +44,6 @@ const reducer = (state = initialState, action) => {
         )
       }
     };
-  case actionTypes.IMPORT_COLUMNS:
-    return action.data;
   case actionTypes.REMOVE_CARD_FROM_COLUMN:
     return {
       ...state,
@@ -78,12 +75,6 @@ export const actions = {
       cardId,
       columnId,
       index
-    };
-  },
-  importColumns: data => {
-    return {
-      type: actionTypes.IMPORT_COLUMNS,
-      data
     };
   },
   removeCardFromColumn: (cardId, columnId) => {

--- a/src/store/tags.js
+++ b/src/store/tags.js
@@ -6,9 +6,7 @@ export const initialState = {};
 export const actionTypes = {
   CREATE_TAG: 'CREATE_TAG',
   SET_TAG_COLORS: 'SET_TAG_COLORS',
-  SET_TAG_NAME: 'SET_TAG_NAME',
-  IMPORT_TAGS: 'IMPORT_TAGS'
-
+  SET_TAG_NAME: 'SET_TAG_NAME'
 };
 
 const reducer = (state = initialState, action) => {
@@ -35,8 +33,6 @@ const reducer = (state = initialState, action) => {
         name: action.name
       }
     };
-  case actionTypes.IMPORT_TAGS:
-    return action.data;
   default:
     return state;
   }
@@ -68,13 +64,7 @@ export const actions = {
       name,
       id
     };
-  },
-  importTags: data => {
-    return {
-      type: actionTypes.IMPORT_TAGS,
-      data
-    };
-  },
+  }
 };
 
 export default reducer;


### PR DESCRIPTION
**What:**

This PR uses a different method to import data from JSON, which seems to be more efficient and less problematic.

**Why:**

The previous implementation was likely to run into issues with nesting and interdependence, which would be extremely annoying later down the line. To remedy this issue, I am introducing a new way to import data from an external source.

**How:**

Using [`replaceReducer`](https://redux.js.org/api/store#replacereducernextreducer), we can temporarily hijack the state's reducer in `importFromJSON` and actually pass the data as-is from the imported JSON via a singular `dispatch`. Then, we can use `replaceReducer` once more to restore the previous reducer, allowing the application to resume properly. This way all of our state reconciliation happens at once and there are no edge-cases where things might break.